### PR TITLE
Rewrite tests using Ammonite-ops.

### DIFF
--- a/migrations/slick/build.sbt
+++ b/migrations/slick/build.sbt
@@ -7,5 +7,6 @@ libraryDependencies ++= List(
   ,"com.typesafe" % "config" % "1.3.0"
   ,"org.slf4j" % "slf4j-nop" % "1.6.4" // <- disables logging
   ,"org.scalatest" % "scalatest_2.11" % "2.2.4" % "test"
+  ,"com.lihaoyi" %% "ammonite-ops" % "0.4.7" % "test"
   ,"commons-io" % "commons-io" % "2.4" % "test"
 )

--- a/migrations/slick/src/test/scala/MigrationDatabaseTests.scala
+++ b/migrations/slick/src/test/scala/MigrationDatabaseTests.scala
@@ -1,129 +1,102 @@
 import org.scalatest._
 import java.io.File
-import java.nio.file.{Paths, Files, StandardCopyOption}
+import scala.language.implicitConversions
 import org.apache.commons.io.FileUtils
-import scala.sys.process._
 import collection.mutable.ListBuffer
+import ammonite.ops._
 import com.liyaos.forklift.slick.tools.git.H2MigrationDatabase
 
-class TestDir {
-  val path = "tmp"
-  val testPath = path + "/test"
-
-  var dir: Option[File] = None
-  var testDir: Option[File] = None
+class TestDir(cwd: Path) {
+  val path = cwd/'tmp
+  val testPath = path/'test
 
   def setup() {
-    FileUtils.deleteDirectory(new File(path))
-    val theDir = new File(path)
-    if (!theDir.exists) theDir.mkdir()
-    dir = Some(theDir)
-    val theTestDir = new File(testPath)
-    if (!theTestDir.exists) theTestDir.mkdir()
-    testDir = Some(theTestDir)
-    val example = new File(System.getProperty("user.dir") + "/example")
-    FileUtils.copyDirectory(example, theTestDir)
+    rm! path
+    mkdir! path
+    cp(cwd/'example, testPath)
   }
 
-  override def toString = path
+  override def toString = path.toString
 }
 
 class MigrationDatabaseTest extends FlatSpec
     with BeforeAndAfter with GivenWhenThen {
-  val dir = new TestDir
-  val objDir = dir.testPath + "/.db"
+  val wd = cwd
+  val dir = new TestDir(wd)
+  val testDir = dir.testPath
+  val objDir = testDir/".db"
+
+  implicit def pathToString(path: Path) = path.toString
 
   before {
     dir.setup()
-    FileUtils.deleteDirectory(new File(objDir))
-    assert(runInDir(Seq("git", "init")) === 0)
-    assert(runInDir(Seq("git", "config", "user.email", "'test@test.com'")) === 0)
-    assert(runInDir(Seq("git", "config", "user.name", "'Tester'")) === 0)
-  }
-
-  def inTestDir(commands: Seq[String]) = {
-    dir.testDir match {
-      case Some(testDir) =>
-        Process(commands, testDir)
-      case None =>
-        throw new RuntimeException("the test dir has not been created yet!")
-    }
-  }
-
-  def runInTestDir(commands: Seq[String]) = {
-    inTestDir(commands) ! ProcessLogger(line => println(line),
-      line => println(line))
-  }
-
-  def inDir(commands: Seq[String]) = {
-    dir.dir match {
-      case Some(dir) =>
-        Process(commands, dir)
-      case None =>
-        throw new RuntimeException("the tmp dir has not been created yet!")
-    }
-  }
-
-  def runInDir(commands: Seq[String]) = {
-    inDir(commands) ! ProcessLogger(line => println(line),
-      line => println(line))
+    rm(objDir)
+    implicit val wd = dir.path
+    assert((%git 'init) === 0)
+    assert((%git('config, "user.email", "test@test.com")) === 0)
+    assert((%git('config, "user.name", "Testser")) === 0)
   }
 
   "commit" should "copy db into .db on master branch" in {
+    implicit val wd = dir.testPath
+
     Given("an example project")
-    assert(runInTestDir(Seq("sbt", "git-tools/run install")) === 0)
-    assert(runInTestDir(Seq("sbt", "git-tools/run rebuild")) === 0)
+    assert((%sbt("git-tools/run install")) === 0)
+    assert((%sbt("git-tools/run rebuild")) === 0)
 
     When("commit on master branch")
-    assert(runInDir(Seq("git", "add", ".")) === 0)
-    assert(runInDir(Seq("git", "commit", "-m", "test")) === 0)
+    assert((%git("add", ".")) === 0)
+    assert((%git("commit", "-m", "test")) === 0)
 
     Then("a db file should be stored in objDir")
-    val dbFile = new File(objDir + "/master/db")
+    val dbFile = new File(objDir/'master/'db)
     assert(dbFile.exists === true)
     assert(dbFile.isFile === true)
 
     And("the stored db should be identical with current db")
     assert(FileUtils.contentEquals(dbFile,
-      new File(dir.testPath + "/test.tb.h2.db")) === true)
+      new File(dir.testPath/"test.tb.h2.db")) === true)
   }
 
   it should "copy db into .db on test branch" in {
+    implicit val wd = dir.testPath
+
     Given("an example project")
-    assert(runInTestDir(Seq("sbt", "git-tools/run install")) === 0)
-    assert(runInTestDir(Seq("sbt", "git-tools/run rebuild")) === 0)
+    assert((%sbt("git-tools/run install")) === 0)
+    assert((%sbt("git-tools/run rebuild")) === 0)
 
     When("commit on master branch")
-    assert(runInDir(Seq("git", "checkout", "-b", "test")) === 0)
-    assert(runInDir(Seq("git", "add", ".")) === 0)
-    assert(runInDir(Seq("git", "commit", "-m", "test")) === 0)
+    assert((%git("checkout", "-b", "test")) === 0)
+    assert((%git("add", ".")) === 0)
+    assert((%git("commit", "-m", "test")) === 0)
 
     Then("a db file should be stored in objDir")
-    val dbFile = new File(objDir + "/test/db")
+    val dbFile = new File(objDir/'test/'db)
     assert(dbFile.exists === true)
     assert(dbFile.isFile === true)
 
     And("the stored db should be identical with current db")
     assert(FileUtils.contentEquals(dbFile,
-      new File(dir.testPath + "/test.tb.h2.db")) === true)
+      new File(dir.testPath/"test.tb.h2.db")) === true)
   }
 
   "checkout" should "use the db of the target branch" in {
+    implicit val wd = dir.testPath
+
     Given("an example project with two branches and one commit on test branch")
-    assert(runInDir(Seq("git", "add", "test/build.sbt")) === 0)
-    assert(runInDir(Seq("git", "commit", "-m", "initial")) === 0)
-    assert(runInDir(Seq("git", "checkout", "-b", "test")) === 0)
-    assert(runInTestDir(Seq("sbt", "git-tools/run install")) === 0)
-    assert(runInTestDir(Seq("sbt", "git-tools/run rebuild")) === 0)
-    val tmpFile = new File(dir.testPath + "/test_file")
-    tmpFile.createNewFile()
-    assert(runInDir(Seq("git", "add", tmpFile.getAbsolutePath)) === 0)
-    assert(runInDir(Seq("git", "commit", "-m", "test")) === 0)
-    assert(runInDir(Seq("git", "checkout", "master")) === 0)
-    new File(dir.testPath + "/test.tb.h2.db").delete()
+    assert((%git("add", "build.sbt")) === 0)
+    assert((%git("commit", "-m", "initial")) === 0)
+    assert((%git("checkout", "-b", "test")) === 0)
+    assert((%sbt("git-tools/run install")) === 0)
+    assert((%sbt("git-tools/run rebuild")) === 0)
+    write(wd/"test_file", "Hello World!")
+    assert((%git("add", wd/"test_file")) === 0)
+    assert((%git("commit", "-m", "test")) === 0)
+    assert((%git("checkout", "master")) === 0)
+    rm! dir.testPath/"test.tb.h2.db"
 
     When("checkout to test branch")
-    assert(runInDir(Seq("git", "checkout", "test")) === 0)
+    assert((%git("checkout", "test")) === 0)
 
     Then("the db should be in the test directory")
     val db = new File(dir.testPath + "/test.tb.h2.db")
@@ -136,40 +109,38 @@ class MigrationDatabaseTest extends FlatSpec
   }
 
   "merge" should "use the db of first parent" in {
-    val m3Name = dir.testPath + "/migrations/src_migrations/main/scala/3.scala"
-    val m3DisabledName = m3Name + ".disabled"
+    implicit val wd = dir.testPath
+
     Given("an example project with two branches with different db")
-    FileUtils.moveFile(new File(m3Name), new File(m3DisabledName))
-    assert(runInTestDir(Seq("sbt", "git-tools/run install")) === 0)
-    assert(runInTestDir(Seq("sbt", "git-tools/run rebuild")) === 0)
-    for (dir <- dir.dir) {
-      FileUtils.copyFileToDirectory(new File(".gitignore"), dir)
-    }
-    assert(runInDir(Seq("git", "add", ".")) === 0)
-    assert(runInDir(Seq("git", "commit", "-m", "initial")) === 0)
-    assert(runInDir(Seq("git", "checkout", "-b", "test")) === 0)
-    FileUtils.moveFile(new File(m3DisabledName), new File(m3Name))
-    assert(runInTestDir(Seq("sbt", "git-tools/run rebuild")) === 0)
-    assert(runInDir(Seq("git", "add", ".")) === 0)
-    assert(runInDir(Seq("git", "commit", "-m", "test")) === 0)
-    assert(runInDir(Seq("git", "checkout", "master")) === 0)
-    val tmpFile = new File(dir.testPath + "/test_file")
-    tmpFile.createNewFile()
-    assert(runInDir(Seq("git", "add", tmpFile.getAbsolutePath)) === 0)
-    assert(runInDir(Seq("git", "commit", "-m", "master")) === 0)
+    val sourcePath = dir.testPath/'migrations/'src_migrations/'main/'scala
+    mv(sourcePath/"3.scala", sourcePath/"3.scala.disabled")
+    assert((%sbt("git-tools/run install")) === 0)
+    assert((%sbt("git-tools/run rebuild")) === 0)
+    write(dir.path/".gitignore", "*.disabled\n*.db")
+    assert((%git("add", ".")) === 0)
+    assert((%git("commit", "-m", "initial")) === 0)
+    assert((%git("checkout", "-b", "test")) === 0)
+    mv(sourcePath/"3.scala.disabled", sourcePath/"3.scala")
+    assert((%sbt("git-tools/run rebuild")) === 0)
+    assert((%git("add", ".")) === 0)
+    assert((%git("commit", "-m", "test")) === 0)
+    assert((%git("checkout", "master")) === 0)
+    write(wd/"test_file", "Hello World!")
+    assert((%git("add", wd/"test_file")) === 0)
+    assert((%git("commit", "-m", "master")) === 0)
 
     When("two branches are merged")
-    assert(runInDir(Seq("git", "merge", "test")) === 0)
+    assert((%git("merge", "test", "-m", "merge")) === 0)
 
     Then("the db should be in test directory")
-    val db = new File(dir.testPath + "/test.tb.h2.db")
+    val db = new File(dir.testPath/"test.tb.h2.db")
     assert(db.exists === true)
     assert(db.isFile === true)
 
     And("the db is identical to that from master but different from that from test")
     assert(FileUtils.contentEquals(db,
-      new File(objDir + "/master/db")) === true)
+      new File(objDir/'master/'db)) === true)
     assert(FileUtils.contentEquals(db,
-      new File(objDir + "/test/db")) === false)
+      new File(objDir/'test/'db)) === false)
   }
 }


### PR DESCRIPTION
Ammonite-ops can make file operations much simpler (and intuitive).
