### PR TITLE
Sort migration ids before writing to summary file

### DIFF
--- a/core/src/main/scala/Commands.scala
+++ b/core/src/main/scala/Commands.scala
@@ -58,8 +58,11 @@ trait MigrationFilesHandler[T] {
   }
 
   protected def writeSummary(ids: Seq[String]) {
-    val code = "object MigrationSummary {\n" + ids.map(
-      n => "M" + n).mkString("\n") + "\n}\n"
+    // need to sort the migration ids before writing them to
+    // the Summary file, so they are read in and processed
+    // in the correct order.
+    val code = "object MigrationSummary {\n" + ids.sortWith(_.toInt < _.toInt)
+      .map(n => "M" + n).mkString("\n") + "\n}\n"
     val sumFile = new File(handledLoc + "/Summary.scala")
 
     if (!sumFile.exists) sumFile.createNewFile()


### PR DESCRIPTION
I encountered a problem when performing the following steps:
- Use the example project, perform an `mg init` followed by a `mg migrate`
- Delete the database file
- Run another `mg init` followed by a `migrate`
- The migrations failed to run, because the migrations summary file had the migrations listed in an incorrect order (M3, M2, M1) -- it would try to run M3 first and would fail.

This commit ensures that the migrations in the summary file are properly ordered and fixes the above issue.
