### PR TITLE
Remove hardcoded imports in slick migrations

### DIFF
--- a/migrations/slick/src/main/scala/Commands.scala
+++ b/migrations/slick/src/main/scala/Commands.scala
@@ -200,8 +200,7 @@ object M${version} {
       case DBIO =>
         val imports =
           if (version > 1)
-            s"""import datamodel.v${version - 1}.schema.tables.Users
-import datamodel.v${version - 1}.schema.tables.UsersRow"""
+            s"""import ${pkgName("v" + (version - 1))}.tables._"""
           else ""
         s"""import ${driverName}.api._
 import com.liyaos.forklift.slick.DBIOMigration


### PR DESCRIPTION
When adding a new slick migration, the generated code always contains imports for `Users` and `UserRow`. This commit removes those hardcoded import statements.
