### PR TITLE
Make updateOp happen first in migrateOp

### DIFF
--- a/core/src/main/scala/Commands.scala
+++ b/core/src/main/scala/Commands.scala
@@ -115,6 +115,7 @@ trait MigrationCommands[T, S] {
   }
 
   def migrateOp(options: Seq[String]) {
+    updateOp
     val prompt = options.contains("-p")
     if (!notYetAppliedMigrations.isEmpty) {
       for (op <- previewOps) op()
@@ -123,7 +124,6 @@ trait MigrationCommands[T, S] {
       }
       for (op <- applyOps) op()
     }
-    updateOp
   }
   def migrateCommand(options: Seq[String]) {
     migrateOp(options)


### PR DESCRIPTION
In the command list, the description of migrate is:
`migrate   automatically fetch migrations, preview and apply them`

Thus, I believe that `migrateOp` should fetch migrations (i.e. call `updateOp`) first, not last.