### PR TITLE
WIP: Created SqlResourceMigration to read sql from a resource file

### DIFF
--- a/example/migrations/src/main/resources/4.sql
+++ b/example/migrations/src/main/resources/4.sql
@@ -1,0 +1,8 @@
+create table "user_email" (
+  "id" INTEGER NOT NULL PRIMARY KEY,
+  "user_id" INTEGER NOT NULL,
+  "email" VARCHAR NOT NULL
+);
+ALTER TABLE "user_email"
+  ADD FOREIGN KEY ("user_id")
+  REFERENCES "user"("id");

--- a/example/migrations/src_migrations/main/scala/4.scala
+++ b/example/migrations/src_migrations/main/scala/4.scala
@@ -1,0 +1,6 @@
+import slick.jdbc.H2Profile.api._
+import com.liyaos.forklift.slick.SqlResourceMigration
+
+object M4 {
+  MyMigrations.migrations = MyMigrations.migrations :+ SqlResourceMigration(4, slick.jdbc.H2Profile, MyMigrations.class)
+}

--- a/example/migrations/src_migrations/main/scala/4.scala
+++ b/example/migrations/src_migrations/main/scala/4.scala
@@ -2,5 +2,5 @@ import slick.jdbc.H2Profile.api._
 import com.liyaos.forklift.slick.SqlResourceMigration
 
 object M4 {
-  MyMigrations.migrations = MyMigrations.migrations :+ SqlResourceMigration(4, slick.jdbc.H2Profile, MyMigrations.class)
+  MyMigrations.migrations = MyMigrations.migrations :+ SqlResourceMigration(4, slick.jdbc.H2Profile)
 }

--- a/migrations/slick/src/main/scala/Commands.scala
+++ b/migrations/slick/src/main/scala/Commands.scala
@@ -120,6 +120,9 @@ trait SlickMigrationCommands
         case m: SqlMigrationInterface[_] =>
           println(migration.id + " SqlMigration:")
           println("\t" + m.queries.map(_.getDumpInfo.mainInfo).mkString("\n\t"))
+        case m: SqlResourceMigrationInterface[_] =>
+          println(migration.id + " SqlResourceMigration:")
+          println(m.sqlResource)
         case m: DBIOMigration[_] =>
           println(migration.id + " DBIOMigration:")
           println("\t" + m.code)

--- a/migrations/slick/src/main/scala/Commands.scala
+++ b/migrations/slick/src/main/scala/Commands.scala
@@ -122,7 +122,7 @@ trait SlickMigrationCommands
           println("\t" + m.queries.map(_.getDumpInfo.mainInfo).mkString("\n\t"))
         case m: SqlResourceMigrationInterface[_] =>
           println(migration.id + " SqlResourceMigration:")
-          println(m.sqlResource)
+          println(m.sqlQueries)
         case m: DBIOMigration[_] =>
           println(migration.id + " DBIOMigration:")
           println("\t" + m.code)

--- a/migrations/slick/src/main/scala/SqlResourceMigration.scala
+++ b/migrations/slick/src/main/scala/SqlResourceMigration.scala
@@ -1,0 +1,23 @@
+package com.liyaos.forklift.slick
+
+import com.liyaos.forklift.core.Migration
+import slick.dbio.DBIO
+import slick.jdbc.JdbcProfile
+
+import scala.io.Source
+
+trait SqlResourceMigrationInterface[T] extends Migration[T, DBIO[Unit]] {
+  def sqlResource: String
+}
+
+case class SqlResourceMigration[T](id: T, profile: JdbcProfile, clazz: Class[_]) extends SqlResourceMigrationInterface[T] {
+
+  import profile.api._
+
+  val sqlResource = Source.fromInputStream(clazz.getResourceAsStream(s"$id.sql")).mkString
+
+  def up = {
+    slick.dbio.DBIO.seq(List(sqlu"#$sqlResource"):_*)
+  }
+}
+

--- a/migrations/slick/src/main/scala/SqlResourceMigration.scala
+++ b/migrations/slick/src/main/scala/SqlResourceMigration.scala
@@ -14,7 +14,8 @@ case class SqlResourceMigration[T](id: T, profile: JdbcProfile) extends SqlResou
 
   import profile.api._
 
-  val sqlQueries = Source.fromResource(s"$id.sql").mkString
+  private val classLoader = Thread.currentThread().getContextClassLoader
+  val sqlQueries: String = Source.fromInputStream(classLoader.getResourceAsStream(s"$id.sql")).mkString
 
   def up = {
     slick.dbio.DBIO.seq(List(sqlu"#$sqlQueries"):_*)

--- a/migrations/slick/src/main/scala/SqlResourceMigration.scala
+++ b/migrations/slick/src/main/scala/SqlResourceMigration.scala
@@ -7,17 +7,17 @@ import slick.jdbc.JdbcProfile
 import scala.io.Source
 
 trait SqlResourceMigrationInterface[T] extends Migration[T, DBIO[Unit]] {
-  def sqlResource: String
+  def sqlQueries: String
 }
 
-case class SqlResourceMigration[T](id: T, profile: JdbcProfile, clazz: Class[_]) extends SqlResourceMigrationInterface[T] {
+case class SqlResourceMigration[T](id: T, profile: JdbcProfile) extends SqlResourceMigrationInterface[T] {
 
   import profile.api._
 
-  val sqlResource = Source.fromInputStream(clazz.getResourceAsStream(s"$id.sql")).mkString
+  val sqlQueries = Source.fromResource(s"$id.sql").mkString
 
   def up = {
-    slick.dbio.DBIO.seq(List(sqlu"#$sqlResource"):_*)
+    slick.dbio.DBIO.seq(List(sqlu"#$sqlQueries"):_*)
   }
 }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.1"
+version in ThisBuild := "0.3.2-SNAPSHOT"


### PR DESCRIPTION
Uses the Migration id to look for $id.sql in the resources of the provided class
(could not find a good way to divine this class automatically).

Wasn't able to figure out how to run the current tests from either sbt or IntelliJ, so have not added tests go along and could use feedback on whether this is the right direction for inclusion in forklift.

I did test it against a local forklift test app and it seems to work as advertised