### PR TITLE
Use MyMigrationManager in MyMigrations

### DIFF
--- a/example/migrations/src/main/scala/Migrations.scala
+++ b/example/migrations/src/main/scala/Migrations.scala
@@ -1,9 +1,10 @@
 import com.liyaos.forklift.slick._
+import example.migration.manager.MyMigrationManager
 
 object MyMigrations extends App
     with SlickMigrationCommandLineTool
     with SlickMigrationCommands
-    with SlickMigrationManager
+    with MyMigrationManager
     with Codegen {
   MigrationSummary
   execCommands(args.toList)


### PR DESCRIPTION
`MyMigrationManager` is defined in the `migration_manager` project but not used anywhere.